### PR TITLE
HOTFIX define SDKPATHINSTALL

### DIFF
--- a/conf/local.conf
+++ b/conf/local.conf
@@ -46,7 +46,7 @@ PACKAGE_CLASSES = "package_ipk"
 SDKMACHINE ??= "x86_64"
 SDK_NAME_PREFIX = "trik-sdk"
 SDKPATH = "/opt/${SDK_NAME_PREFIX}"
-
+SDKPATHINSTALL = "/opt/${SDK_NAME_PREFIX}"
 
 MAX_ATOMIC_WIDTH[arm-eabi] = "64"
 EXTRA_IMAGE_FEATURES += "debug-tweaks tools-debug x11-base"


### PR DESCRIPTION
You need to define a new variable SDKPATHINSTALL to specify the target path for installing the SDK.