### PR TITLE
meta-ros: disable fortran group to skip gfortran

### DIFF
--- a/conf/local.conf
+++ b/conf/local.conf
@@ -16,6 +16,10 @@ BUILDHISTORY_COMMIT = "1"
 #BBMASK = "meta-ros/recipes-extended/wxwidgets|meta-ros/recipes-support/boost|"
 #BBMASK = "meta/recipes-core/jpeg/"
 
+# meta-ros enables gfortran by default for all distro ros (f.e. for "lapack" lib) 
+# which we don't use, so disable it
+ROS_WORLD_SKIP_GROUPS += "fortran"
+
 # What kind of additional images do we want?
 # default is sdimg.xz, but ext4, ext4.xz and uncompressed sdimg are possible
 IMAGE_FSTYPES = ""

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:jammy
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y --no-install-recommends gawk wget git diffstat unzip texinfo gcc build-essential chrpath socat cpio python3 python3-pip python3-pexpect xz-utils debianutils iputils-ping python3-git python3-jinja2 python3-subunit zstd liblz4-tool file locales libacl1 gfortran
+RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y --no-install-recommends gawk wget git diffstat unzip texinfo gcc build-essential chrpath socat cpio python3 python3-pip python3-pexpect xz-utils debianutils iputils-ping python3-git python3-jinja2 python3-subunit zstd liblz4-tool file locales libacl1
 RUN locale-gen en_US.UTF-8
 ARG host_uid=1001
 ARG host_gid=1001


### PR DESCRIPTION
meta-ros enables gfortran by default for all distro ros (e.g. for lapack), which we don't use. Disable the fortran group via ROS_WORLD_SKIP_GROUPS so gfortran is no longer installed on host.